### PR TITLE
Add a method to get the bytes as a vec for an entry in the rar file.

### DIFF
--- a/examples/basic_bytes.rs
+++ b/examples/basic_bytes.rs
@@ -1,0 +1,16 @@
+extern crate env_logger;
+extern crate unrar;
+
+use std::str;
+use unrar::Archive;
+
+fn main() {
+    env_logger::init().unwrap();
+    println!(
+        "{}",
+        str::from_utf8(&Archive::new("version.rar".into())
+            .read_bytes("VERSION")
+            .unwrap())
+            .unwrap()
+    );
+}

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,0 +1,12 @@
+extern crate unrar;
+
+use std::str;
+
+#[test]
+fn version_cat() {
+    let bytes = &unrar::Archive::new("data/version.rar".into())
+        .read_bytes("VERSION")
+        .unwrap();
+    let s = str::from_utf8(bytes).unwrap();
+    assert_eq!(s, "unrar-0.4.0");
+}


### PR DESCRIPTION
I needed this for my use case (and didn't want to go the route of creating a temporary directory to extract too), so thought it might be useful for other people as well.