### PR TITLE
Fix unrar_sys build on windows (gnu/msvc)

### DIFF
--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -1,13 +1,30 @@
 extern crate cc;
 
-use std::env::set_var;
-
 fn main() {
-    set_var("LIBFLAGS", "-fPIC");
-    set_var("LDFLAGS", "-pthread");
-    set_var("CXXFLAGS", "-O2");
+    if cfg!(windows) {
+        println!("cargo:rustc-flags=-lpowrprof");
+        println!("cargo:rustc-link-lib=shell32");
+        if cfg!(target_env = "gnu") {
+            println!("cargo:rustc-link-lib=pthread");
+        }
+    } else {
+        println!("cargo:rustc-link-lib=pthread");
+    }
     cc::Build::new()
         .cpp(true) // Switch to C++ library compilation.
+        .opt_level(2)
+        .warnings(false)
+        .flag_if_supported("-fPIC")
+        .flag_if_supported("-Wno-switch")
+        .flag_if_supported("-Wno-parentheses")
+        .flag_if_supported("-Wno-macro-redefined")
+        .flag_if_supported("-Wno-dangling-else")
+        .flag_if_supported("-Wno-logical-op-parentheses")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-variable")
+        .flag_if_supported("-Wno-unused-function")
+        .flag_if_supported("-Wno-missing-braces")
+        .flag_if_supported("-Wno-unknown-pragmas")
         .define("_FILE_OFFSET_BITS", Some("64"))
         .define("_LARGEFILE_SOURCE", None)
         .define("RAR_SMP", None)


### PR DESCRIPTION
There were some linking errors under Windows on both toolchains, this should fix that.
While at it I took the liberty to refactor the `build.rs` a bit.