### PR TITLE
unrar_sys related fixes and tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = "list and extract RAR archives"
 repository = "https://github.com/muja/unrar.rs"
 
 [dependencies]
-libc = "0.2"
 regex = "1"
 lazy_static = "1"
 enum_primitive = "0.1"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,6 +1,6 @@
 use native;
 use regex::Regex;
-use libc::{c_uint, c_long, c_int};
+use libc::c_int;
 use std::str;
 use std::fmt;
 use std::ffi::CStr;
@@ -233,7 +233,8 @@ impl OpenArchive {
         }
     }
 
-    extern "C" fn callback(msg: c_uint, user_data: c_long, p1: c_long, p2: c_long) -> c_int {
+    extern "C" fn callback(msg: native::UINT, user_data: native::LPARAM,
+                           p1: native::LPARAM, p2: native::LPARAM) -> c_int {
         // println!("msg: {}, user_data: {}, p1: {}, p2: {}", msg, user_data, p1, p2);
         match msg {
             native::UCM_CHANGEVOLUME => {
@@ -263,7 +264,7 @@ impl Iterator for OpenArchive {
         }
         let mut volume = None;
         unsafe {
-            native::RARSetCallback(self.handle, Self::callback, &mut volume as *mut _ as c_long)
+            native::RARSetCallback(self.handle, Self::callback, &mut volume as *mut _ as native::LPARAM)
         }
         let mut header = native::HeaderData::default();
         let read_result =

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,6 +1,6 @@
 use native;
 use regex::Regex;
-use libc::c_int;
+use std::os::raw::c_int;
 use std::str;
 use std::fmt;
 use std::ffi::CStr;

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -5,6 +5,7 @@ use std::str;
 use std::fmt;
 use std::ffi::CStr;
 use std::iter::repeat;
+use std::ptr::NonNull;
 use error::*;
 
 macro_rules! cstr {
@@ -184,7 +185,7 @@ impl<'a> Archive<'a> {
 
 #[derive(Debug)]
 pub struct OpenArchive {
-    handle: native::Handle,
+    handle: NonNull<native::HANDLE>,
     operation: Operation,
     destination: Option<String>,
     damaged: bool,
@@ -199,13 +200,13 @@ impl OpenArchive {
            -> UnrarResult<Self> {
         let mut data = native::OpenArchiveData::new(cstr!(filename).as_ptr() as *const _,
                                                     mode as u32);
-        let handle = unsafe { native::RAROpenArchive(&mut data as *mut _) };
+        let handle = NonNull::new(unsafe { native::RAROpenArchive(&mut data as *mut _) }
+                                  as *mut _);
         let result = Code::from(data.open_result).unwrap();
-        if handle.is_null() {
-            Err(UnrarError::from(result, When::Open))
-        } else {
+
+        if let Some(handle) = handle {
             if let Some(pw) = password {
-                unsafe { native::RARSetPassword(handle, cstr!(pw).as_ptr() as *const _) }
+                unsafe { native::RARSetPassword(handle.as_ptr(), cstr!(pw).as_ptr() as *const _) }
             }
             let dest = destination.map(|path| cstr!(path));
             let archive = OpenArchive {
@@ -214,10 +215,13 @@ impl OpenArchive {
                 damaged: false,
                 operation: operation,
             };
+
             match result {
                 Code::Success => Ok(archive),
                 _ => Err(UnrarError::new(result, When::Open, archive)),
             }
+        } else {
+            Err(UnrarError::from(result, When::Open))
         }
     }
 
@@ -264,17 +268,17 @@ impl Iterator for OpenArchive {
         }
         let mut volume = None;
         unsafe {
-            native::RARSetCallback(self.handle, Self::callback, &mut volume as *mut _ as native::LPARAM)
+            native::RARSetCallback(self.handle.as_ptr(), Self::callback, &mut volume as *mut _ as native::LPARAM)
         }
         let mut header = native::HeaderData::default();
         let read_result =
-            Code::from(unsafe { native::RARReadHeader(self.handle, &mut header as *mut _) as u32 })
+            Code::from(unsafe { native::RARReadHeader(self.handle.as_ptr(), &mut header as *mut _) as u32 })
                 .unwrap();
         match read_result {
             Code::Success => {
                 let process_result = Code::from(unsafe {
                                          native::RARProcessFile(
-                        self.handle,
+                        self.handle.as_ptr(),
                         self.operation as i32,
                         self.destination.as_ref().map(
                             |x| x.as_ptr() as *const _
@@ -313,7 +317,7 @@ impl Iterator for OpenArchive {
 impl Drop for OpenArchive {
     fn drop(&mut self) {
         unsafe {
-            native::RARCloseArchive(self.handle);
+            native::RARCloseArchive(self.handle.as_ptr());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate unrar_sys as native;
 extern crate regex;
-extern crate libc;
 extern crate num;
 #[macro_use]
 extern crate lazy_static;

--- a/unrar_sys/Cargo.toml
+++ b/unrar_sys/Cargo.toml
@@ -9,7 +9,7 @@ description = "FFI bindings to unrar (with minimal abstractions)"
 repository = "https://github.com/muja/unrar.rs"
 
 [features]
-default = []
+default = ["std"]
 std = ["libc/std", "winapi/std"]
 
 [dependencies]

--- a/unrar_sys/Cargo.toml
+++ b/unrar_sys/Cargo.toml
@@ -8,11 +8,15 @@ license = "MIT"
 description = "FFI bindings to unrar (with minimal abstractions)"
 repository = "https://github.com/muja/unrar.rs"
 
+[features]
+default = []
+std = ["libc/std", "winapi/std"]
+
 [dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 
 [build-dependencies]
 cc = "1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+winapi = { version = "0.3", features = ["minwindef", "ntdef"] }

--- a/unrar_sys/Cargo.toml
+++ b/unrar_sys/Cargo.toml
@@ -13,3 +13,6 @@ libc = "0.2"
 
 [build-dependencies]
 cc = "1"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -1,9 +1,20 @@
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
 extern crate libc;
+
 #[cfg(all(windows, target_env = "msvc"))]
 extern crate winapi;
 
-use libc::{c_int, c_uint, wchar_t, c_uchar};
-use std::os::raw::c_char;
+#[cfg(feature = "std")]
+use std::os::raw::{c_int, c_uint, c_uchar, c_char};
+#[cfg(feature = "std")]
+use libc::wchar_t;
+
+#[cfg(not(feature = "std"))]
+use libc::{c_int, c_uint, wchar_t, c_uchar, c_char};
 
 // ----------------- ENV SPECIFIC ----------------- //
 
@@ -18,6 +29,11 @@ mod env {
 #[cfg(not(all(windows, target_env = "msvc")))]
 mod env {
     use super::*;
+
+    #[cfg(feature = "std")]
+    use std::os::raw::c_long;
+
+    #[cfg(not(feature = "std"))]
     use libc::c_long;
 
     pub type LPARAM = c_long;

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -1,6 +1,35 @@
 extern crate libc;
+#[cfg(all(windows, target_env = "msvc"))]
+extern crate winapi;
 
-use libc::{c_int, c_uint, wchar_t, c_long, c_char, c_void, c_uchar};
+use libc::{c_int, c_uint, wchar_t, c_uchar};
+use std::os::raw::c_char;
+
+// ----------------- ENV SPECIFIC ----------------- //
+
+#[cfg(all(windows, target_env = "msvc"))]
+mod env {
+    pub use {
+        winapi::shared::minwindef::{LPARAM, UINT},
+        winapi::shared::ntdef::LONG,
+    };
+}
+
+#[cfg(not(all(windows, target_env = "msvc")))]
+mod env {
+    use super::*;
+    use libc::c_long;
+
+    pub type LPARAM = c_long;
+    pub type LONG = c_long;
+    pub type UINT = c_uint;
+}
+
+pub use self::env::LPARAM;
+pub use self::env::LONG;
+pub use self::env::UINT;
+
+pub type WCHAR = wchar_t;
 
 // ----------------- CONSTANTS ----------------- //
 
@@ -29,8 +58,8 @@ pub const RAR_SKIP: c_int = 0;
 pub const RAR_TEST: c_int = 1;
 pub const RAR_EXTRACT: c_int = 2;
 
-pub const RAR_VOL_ASK: c_long = 0;
-pub const RAR_VOL_NOTIFY: c_long = 1;
+pub const RAR_VOL_ASK: LPARAM = 0;
+pub const RAR_VOL_NOTIFY: LPARAM = 1;
 
 pub const RAR_HASH_NONE: c_uint = 0;
 pub const RAR_HASH_CRC32: c_uint = 1;
@@ -43,11 +72,11 @@ pub const RHDF_ENCRYPTED: c_uint = 1 << 2; // 4, 0x4
 pub const RHDF_SOLID: c_uint = 1 << 4; // 16, 0x10
 pub const RHDF_DIRECTORY: c_uint = 1 << 5; // 32, 0x20
 
-pub const UCM_CHANGEVOLUME: c_uint = 0;
-pub const UCM_PROCESSDATA: c_uint = 1;
-pub const UCM_NEEDPASSWORD: c_uint = 2;
-pub const UCM_CHANGEVOLUMEW: c_uint = 3;
-pub const UCM_NEEDPASSWORDW: c_uint = 4;
+pub const UCM_CHANGEVOLUME: UINT = 0;
+pub const UCM_PROCESSDATA: UINT = 1;
+pub const UCM_NEEDPASSWORD: UINT = 2;
+pub const UCM_CHANGEVOLUMEW: UINT = 3;
+pub const UCM_NEEDPASSWORDW: UINT = 4;
 
 // RAROpenArchiveDataEx::Flags
 pub const ROADF_VOLUME: c_uint = 0x0001;
@@ -65,7 +94,7 @@ pub const ROADOF_KEEPBROKEN: c_uint = 0x0001;
 
 pub type ChangeVolProc = extern "C" fn(*mut c_char, c_int) -> c_int;
 pub type ProcessDataProc = extern "C" fn(*mut c_uchar, c_int) -> c_int;
-pub type Callback = extern "C" fn(c_uint, c_long, c_long, c_long) -> c_int;
+pub type Callback = extern "C" fn(UINT, LPARAM, LPARAM, LPARAM) -> c_int;
 
 #[repr(C)]
 pub struct HANDLE { _private: [u8; 0] }
@@ -152,7 +181,7 @@ pub struct OpenArchiveDataEx {
     pub comment_state: c_uint,
     pub flags: c_uint,
     pub callback: Option<Callback>,
-    pub user_data: c_long,
+    pub user_data: LPARAM,
     pub op_flags: c_uint,
     pub comment_buffer_w: *mut wchar_t,
     pub reserved: [c_uint; 25],
@@ -184,7 +213,7 @@ extern "C" {
                            dest_name: *const wchar_t)
                            -> c_int;
 
-    pub fn RARSetCallback(handle: Handle, callback: Callback, user_data: c_long);
+    pub fn RARSetCallback(handle: Handle, callback: Callback, user_data: LPARAM);
 
     pub fn RARSetChangeVolProc(handle: Handle, change_vol_proc: ChangeVolProc);
 

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -67,7 +67,9 @@ pub type ChangeVolProc = extern "C" fn(*mut c_char, c_int) -> c_int;
 pub type ProcessDataProc = extern "C" fn(*mut c_uchar, c_int) -> c_int;
 pub type Callback = extern "C" fn(c_uint, c_long, c_long, c_long) -> c_int;
 
-pub type Handle = *const c_void;
+#[repr(C)]
+pub struct HANDLE { _private: [u8; 0] }
+pub type Handle = *const HANDLE;
 
 // ----------------- STRUCTS ----------------- //
 


### PR DESCRIPTION
There's 4 kind of interrelated changes here:
1. Use [winapi](https://crates.io/crates/winapi) types when using MSVC toolchain through type aliases (`LPARAM`, `UINT`, `LONG`). Particularly because `c_long` (replaced by `LPARAM`) is 32-bit with MSVC, so it's not suitable for representing pointers on 64-bit Windows. This can be observed by the multipart test failing with an access violation on MSVC toolchain.

2. Made an opaque type out of `Handle` and stored it in a `NonNull`. Giving some type safety, and allowing for some compiler optimizations.

3. Added `std` feature flag to `unrar_sys` and made it `#![no_std]` by default.

4. Removed (now mostly unnecessary) `libc` dependency from `unrar`, switched to using `std::os::raw::c_int`.