### PR TITLE
Fix issue #7

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -198,7 +198,8 @@ impl OpenArchive {
            destination: Option<String>,
            operation: Operation)
            -> UnrarResult<Self> {
-        let mut data = native::OpenArchiveData::new(cstr!(filename).as_ptr() as *const _,
+        let filename = cstr!(filename);
+        let mut data = native::OpenArchiveData::new(filename.as_ptr() as *const _,
                                                     mode as u32);
         let handle = NonNull::new(unsafe { native::RAROpenArchive(&mut data as *mut _) }
                                   as *mut _);
@@ -206,7 +207,8 @@ impl OpenArchive {
 
         if let Some(handle) = handle {
             if let Some(pw) = password {
-                unsafe { native::RARSetPassword(handle.as_ptr(), cstr!(pw).as_ptr() as *const _) }
+                let pw = cstr!(pw);
+                unsafe { native::RARSetPassword(handle, pw.as_ptr() as *const _) }
             }
             let dest = destination.map(|path| cstr!(path));
             let archive = OpenArchive {


### PR DESCRIPTION
Fixes the use-after-free by ensuring that the string is bound, and that the binding lives as long as the pointer is in use.

For now I ignored the fact that I think `String` is the wrong type to use here, as I've got a bigger PR brewing to deal with that.