### PR TITLE
Build fix macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Build
+      run: cargo build
+    - name: Run tests
+      run: cargo test --verbose
+

--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -14,6 +14,7 @@ fn main() {
         .cpp(true) // Switch to C++ library compilation.
         .opt_level(2)
         .warnings(false)
+        .flag("-stdlib=libc++")
         .flag_if_supported("-fPIC")
         .flag_if_supported("-Wno-switch")
         .flag_if_supported("-Wno-parentheses")


### PR DESCRIPTION
This fix the issue on MacOS where the build fails because of the missing include `<new>` I get when trying to build unrar on Github Action runner (https://github.com/IohannRabeson/hudhub/actions/runs/4348975898/jobs/7598301157)