### PR TITLE
Fix build on Github Actions Macos.

### DIFF
--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -14,6 +14,7 @@ fn main() {
         .cpp(true) // Switch to C++ library compilation.
         .opt_level(2)
         .warnings(false)
+        .flag("-stdlib=libc++")
         .flag_if_supported("-fPIC")
         .flag_if_supported("-Wno-switch")
         .flag_if_supported("-Wno-parentheses")


### PR DESCRIPTION
This fix the issue on MacOS where the build fails because of the missing include `<new>`.  
This issue happens when trying to build unrar on a Githuab Action's runner: 
https://github.com/IohannRabeson/hudhub/actions/runs/4348975898/jobs/7598301157