### PR TITLE
Fix x86_64-pc-windows-gnu target build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unrar"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
   "Danyel Bayraktar <rust@danyel.io>",
   "vjoki <vjoki@zv.fi>",

--- a/unrar_sys/Cargo.toml
+++ b/unrar_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unrar_sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Danyel Bayraktar <rust@danyel.io>"]
 
 build = "build.rs"

--- a/unrar_sys/Cargo.toml
+++ b/unrar_sys/Cargo.toml
@@ -19,5 +19,5 @@ libc = { version = "0.2", default-features = false }
 [build-dependencies]
 cc = "1"
 
-[target.'cfg(all(windows, target_env = "msvc"))'.dependencies]
+[target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "ntdef"] }

--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -65,6 +65,7 @@ fn main() {
         .cpp_link_stdlib(None)
         .warnings(false)
         .extra_warnings(false)
+        .flag_if_supported("-w") // inhibit all warnings on gcc
         .flag_if_supported("-stdlib=libc++")
         .flag_if_supported("-fPIC")
         .flag_if_supported("-Wno-switch")

--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -9,7 +9,6 @@ fn main() {
         println!("cargo:rustc-link-lib=pthread");
     }
     let files: Vec<String> = [
-        "rar",
         "strlist",
         "strfn",
         "pathfn",
@@ -28,7 +27,6 @@ fn main() {
         "crc",
         "rawread",
         "encname",
-        "resource",
         "match",
         "timefn",
         "rdwrfn",
@@ -62,9 +60,11 @@ fn main() {
     cc::Build::new()
         .cpp(true) // Switch to C++ library compilation.
         .opt_level(2)
+        .std("c++20")
+        // by default cc crate tries to link against dynamic stdlib, which causes problems on windows-gnu target
+        .cpp_link_stdlib(None)
         .warnings(false)
-        .flag("-std=c++11")
-        .flag_if_supported("-stdlib=libc++")
+        .extra_warnings(false)
         .flag_if_supported("-fPIC")
         .flag_if_supported("-Wno-switch")
         .flag_if_supported("-Wno-parentheses")
@@ -76,6 +76,7 @@ fn main() {
         .flag_if_supported("-Wno-unused-function")
         .flag_if_supported("-Wno-missing-braces")
         .flag_if_supported("-Wno-unknown-pragmas")
+        .flag_if_supported("-Wno-deprecated-declarations")
         .define("_FILE_OFFSET_BITS", Some("64"))
         .define("_LARGEFILE_SOURCE", None)
         .define("RAR_SMP", None)

--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -65,6 +65,7 @@ fn main() {
         .cpp_link_stdlib(None)
         .warnings(false)
         .extra_warnings(false)
+        .flag_if_supported("-stdlib=libc++")
         .flag_if_supported("-fPIC")
         .flag_if_supported("-Wno-switch")
         .flag_if_supported("-Wno-parentheses")

--- a/unrar_sys/build.rs
+++ b/unrar_sys/build.rs
@@ -60,7 +60,7 @@ fn main() {
     cc::Build::new()
         .cpp(true) // Switch to C++ library compilation.
         .opt_level(2)
-        .std("c++20")
+        .std("c++14")
         // by default cc crate tries to link against dynamic stdlib, which causes problems on windows-gnu target
         .cpp_link_stdlib(None)
         .warnings(false)

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -205,6 +205,10 @@ pub struct OpenArchiveDataEx {
 // ----------------- BINDINGS ----------------- //
 
 #[link(name = "unrar", kind = "static")]
+#[cfg_attr(all(windows, target_env = "gnu"), link(name = "stdc++", kind = "static", modifiers = "-bundle"))]
+#[cfg_attr(target_os = "macos", link(name = "c++"))]
+#[cfg_attr(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"), link(name = "c++"))]
+#[cfg_attr(target_os = "linux", link(name = "stdc++"))]
 extern "C" {
     pub fn RAROpenArchive(data: *const OpenArchiveData) -> *const Handle;
 

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -13,7 +13,7 @@ use libc::{c_char, c_int, c_uchar, c_uint};
 
 // ----------------- ENV SPECIFIC ----------------- //
 
-#[cfg(all(windows, target_env = "msvc"))]
+#[cfg(windows)]
 mod env {
     pub use {
         winapi::shared::minwindef::{LPARAM, UINT, UCHAR, INT},
@@ -22,7 +22,7 @@ mod env {
 }
 
 
-#[cfg(not(all(windows, target_env = "msvc")))]
+#[cfg(not(windows))]
 mod env {
     use super::*;
 

--- a/unrar_sys/vendor/unrar/isnt.cpp
+++ b/unrar_sys/vendor/unrar/isnt.cpp
@@ -22,6 +22,7 @@ DWORD WinNT()
   return Result;
 }
 
+#ifdef _MSC_VER
 
 // Replace it with documented Windows 11 check when available.
 #include <comdef.h>
@@ -96,6 +97,16 @@ static bool WMI_IsWindows10()
   return Win10;
 }
 
+#else /* _MSC_VER */
+
+#include <wbemidl.h>
+
+static bool WMI_IsWindows10()
+{
+  return false;
+}
+
+#endif /* _MSC_VER */
 
 // Replace it with actual check when available.
 bool IsWindows11OrGreater()

--- a/unrar_sys/vendor/unrar/os.hpp
+++ b/unrar_sys/vendor/unrar/os.hpp
@@ -47,11 +47,13 @@
 #define WINVER _WIN32_WINNT_VISTA
 #define _WIN32_WINNT _WIN32_WINNT_VISTA
 #else
+#undef WINVER
 #define WINVER _WIN32_WINNT_WINXP
+#undef _WIN32_WINNT
 #define _WIN32_WINNT _WIN32_WINNT_WINXP
 #endif
 
-#if !defined(ZIPSFX)
+#if !defined(ZIPSFX) && !defined(RAR_SMP)
 #define RAR_SMP
 #endif
 
@@ -60,9 +62,15 @@
 #include <windows.h>
 #include <prsht.h>
 #include <shlwapi.h>
+
+#ifdef _MSC_VER
 #pragma comment(lib, "Shlwapi.lib")
 #include <PowrProf.h>
 #pragma comment(lib, "PowrProf.lib")
+#else
+#include <powrprof.h>
+#endif /* _MSC_VER */
+
 #include <shellapi.h>
 #include <shlobj.h>
 #include <winioctl.h>

--- a/unrar_sys/vendor/unrar/os.hpp
+++ b/unrar_sys/vendor/unrar/os.hpp
@@ -47,13 +47,11 @@
 #define WINVER _WIN32_WINNT_VISTA
 #define _WIN32_WINNT _WIN32_WINNT_VISTA
 #else
-#undef WINVER
 #define WINVER _WIN32_WINNT_WINXP
-#undef _WIN32_WINNT
 #define _WIN32_WINNT _WIN32_WINNT_WINXP
 #endif
 
-#if !defined(ZIPSFX) && !defined(RAR_SMP)
+#if !defined(ZIPSFX)
 #define RAR_SMP
 #endif
 
@@ -62,15 +60,9 @@
 #include <windows.h>
 #include <prsht.h>
 #include <shlwapi.h>
-
-#ifdef _MSC_VER
 #pragma comment(lib, "Shlwapi.lib")
 #include <PowrProf.h>
 #pragma comment(lib, "PowrProf.lib")
-#else
-#include <powrprof.h>
-#endif /* _MSC_VER */
-
 #include <shellapi.h>
 #include <shlobj.h>
 #include <winioctl.h>


### PR DESCRIPTION
Latest version of unrar.rs fails to link on x86_64-pc-windows-gnu target.
Root cause is indirect dependency from underlying C++ library to MSVC-provided comsupp.lib.

Proposed patch works around it by enabling this dependency only when using MSVC compiler.
It does drop some Windows version detection heuristics on -gnu targets, but I haven't observed any issues with it during tests.

Additionally, even after linking is fixed using above method, produced build fails during runtime with memory access violation error. This is most probably caused by type size mismatch (32 vs 64bits).
Enabling `winapi` crate usage for all flavours of windows target fixes the issue.