### PR TITLE
fix: fix CJK filename can not open issue

### DIFF
--- a/src/open_archive.rs
+++ b/src/open_archive.rs
@@ -233,10 +233,11 @@ impl<Mode: OpenMode> OpenArchive<Mode, CursorBeforeHeader> {
         password: Option<&[u8]>,
         recover: Option<&mut Option<Self>>,
     ) -> UnrarResult<Self> {
-        let filename = WideCString::from_os_str(&filename).unwrap();
+        let filename = CString::new(filename.to_str().unwrap()).unwrap();
 
         let mut data =
             native::OpenArchiveDataEx::new(filename.as_ptr() as *const _, Mode::VALUE as u32);
+
         let handle =
             NonNull::new(unsafe { native::RAROpenArchiveEx(&mut data as *mut _) } as *mut _);
 

--- a/unrar_sys/Cargo.toml
+++ b/unrar_sys/Cargo.toml
@@ -21,3 +21,6 @@ cc = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "ntdef"] }
+
+[dev-dependencies]
+widestring = "1.0.2"

--- a/unrar_sys/examples/lister.rs
+++ b/unrar_sys/examples/lister.rs
@@ -39,12 +39,12 @@ fn main() {
             &mut next_path as *mut String as LPARAM,
         )
     };
-    let mut header = HeaderData::default();
+    let mut header = HeaderDataEx::default();
     let mut result = 0;
     let mut process_result;
     let mut first = true;
     while result == 0 {
-        result = unsafe { RARReadHeader(handle, &mut header as *mut _) };
+        result = unsafe { RARReadHeaderEx(handle, &mut header as *mut _) };
         if result != ERAR_SUCCESS {
             if result != ERAR_END_ARCHIVE {
                 writeln!(&mut stderr, "Error opening: {}", result).unwrap();
@@ -56,7 +56,7 @@ fn main() {
         }
         first = false;
         let s =
-            str::from_utf8(unsafe { CStr::from_ptr(header.filename.as_ptr()) }.to_bytes()).unwrap();
+            unsafe { widestring::WideCString::from_vec_unchecked(header.filename_w.to_vec().into_iter().map(|x|{x as u32}).collect::<Vec<_>>()) }.to_string().unwrap();
         process_result =
             unsafe { RARProcessFile(handle, RAR_SKIP, std::ptr::null(), std::ptr::null()) };
         println!("{}", s);

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -334,10 +334,10 @@ impl OpenArchiveData {
 }
 
 impl OpenArchiveDataEx {
-    pub fn new(archive: *const wchar_t, mode: c_uint) -> Self {
+    pub fn new(archive: *const c_char, mode: c_uint) -> Self {
         OpenArchiveDataEx {
-            archive_name: std::ptr::null(),
-            archive_name_w: archive,
+            archive_name: archive,
+            archive_name_w: std::ptr::null(),
             open_mode: mode,
             open_result: 0,
             comment_buffer: std::ptr::null_mut(),


### PR DESCRIPTION
the bug will cause CJK chars in filename been stripped out.

for example:

`/media/mydisk/fooにほん.rar ` will result in `/media/mydisk/foo `　so the open will fail


due to

```cpp
    std::string AnsiArcName;
    if (r->ArcName!=nullptr)
    {
      AnsiArcName=r->ArcName;
      if (!AreFileApisANSI())
        IntToExt(r->ArcName,AnsiArcName);
    }

    std::wstring ArcName;
    if (r->ArcNameW!=nullptr && *r->ArcNameW!=0)
      ArcName=r->ArcNameW;
    else
      CharToWide(AnsiArcName,ArcName);

    Data->Cmd.AddArcName(ArcName);
    Data->Cmd.Overwrite=OVERWRITE_ALL;
    Data->Cmd.VersionControl=1;

    Data->Cmd.Callback=r->Callback;
    Data->Cmd.UserData=r->UserData;

    // Open shared mode is added by request of dll users, who need to
    // browse and unpack archives while downloading.
    Data->Cmd.OpenShared = true;
    if (!Data->Arc.Open(ArcName,FMF_OPENSHARED))
    {
      r->OpenResult=ERAR_EOPEN;
      delete Data;
      return NULL;
    }
```

in `Data->Arc.Open` it will do `WideToChar` which cause the CJK bytes got lost.

but if it calls `CharToWide` first (when `ArcNameW` is nullptr), when it do the reverse, it get the right filename back.