### PR TITLE
fix(unrar): extract_to should set parent path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/muja/unrar.rs"
 regex = "1"
 bitflags = "1"
 widestring = "1"
+tempfile = "3.10.1"
 
 [dependencies.unrar_sys]
 path = "unrar_sys"

--- a/src/open_archive.rs
+++ b/src/open_archive.rs
@@ -422,8 +422,12 @@ impl OpenArchive<Process, CursorBeforeFile> {
         self,
         dest: P,
     ) -> UnrarResult<OpenArchive<Process, CursorBeforeHeader>> {
+        let wpath = match dest.as_ref().parent() {
+            Some(parent) => Some(WideCString::from_os_str(parent).expect("Unexpected nul in destination")),
+            None => None,
+        };
         let wdest = WideCString::from_os_str(dest.as_ref()).expect("Unexpected nul in destination");
-        self.process_file::<Extract>(None, Some(&wdest))
+        self.process_file::<Extract>(wpath.as_ref(), Some(&wdest))
     }
 }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::{env::set_current_dir, fs::read_to_string, path::{Path, PathBuf}};
+
+use tempfile::tempdir;
 
 #[test]
 fn version_list() {
@@ -9,6 +11,36 @@ fn version_list() {
         archive.next().unwrap().unwrap().filename,
         PathBuf::from("VERSION")
     );
+}
+
+#[test]
+fn version_extract_to_absolute_path() {
+    let archive = unrar::Archive::new("data/version.rar")
+        .open_for_processing()
+        .unwrap();
+
+    let tmp_dir = tempdir().unwrap();
+
+    let header = archive.read_header().unwrap().unwrap();
+    let filename = header.entry().filename.clone();
+    header.extract_to(tmp_dir.path().join(filename)).unwrap();
+
+    assert_eq!(read_to_string(tmp_dir.path().join("VERSION")).unwrap(), "unrar-0.4.0");
+}
+
+#[test]
+fn version_extract_to_relative_path() {
+    let archive = unrar::Archive::new("data/version.rar")
+        .open_for_processing()
+        .unwrap();
+
+    let tmp_dir = tempdir().unwrap();
+    set_current_dir(&tmp_dir.path()).unwrap();
+
+    let header = archive.read_header().unwrap().unwrap();
+    header.extract_to("some-folder/VERSION").unwrap();
+
+    assert_eq!(read_to_string(tmp_dir.path().join("some-folder/VERSION")).unwrap(), "unrar-0.4.0");
 }
 
 #[test]


### PR DESCRIPTION
It seems that just specifying the `file` does not work with absolute paths, e.g. `/tmp/folder/filename.txt`.

After doing some testing, it seems that providing parent folder as `path` and complete path as `file` is the only thing that consistently works.

I've also added tests, to ensure that both extraction to relative and absolute paths work as expected.