### PR TITLE
fix: remove invalid unicode after PACK_MAX_DICT in unrar code comment

### DIFF
--- a/unrar_sys/vendor/unrar/cmddata.cpp
+++ b/unrar_sys/vendor/unrar/cmddata.cpp
@@ -647,7 +647,7 @@ void CommandData::ProcessSwitch(const wchar *Switch)
             // 2023.07.22: For 4 GB and less we also check that it is power of 2,
             // so archives are compatible with RAR 5.0+.
             // We allow Size>PACK_MAX_DICT here, so we can use -md[x] to unpack
-            // archives created by future versions with higher PACK_MAX_DICTþ
+            // archives created by future versions with higher PACK_MAX_DICT
             uint Flags;
             if ((Size=Archive::GetWinSize(Size,Flags))==0 ||
                 Size<=0x100000000ULL && !IsPow2(Size))


### PR DESCRIPTION
resolve https://github.com/muja/unrar.rs/issues/56

msvc compliler (under some windows system) complains about "undefined identifier Flags" due to invalid chars 

(for example, Windows 11,  has system locale for non-unicode app configured as Japenese or Koeran or Chinese)
  
![image](https://github.com/user-attachments/assets/4b1339ed-80d0-425c-b001-32be5895cd2a)
