### PR TITLE
Use libstdc++ on NetBSD

### DIFF
--- a/src/pathed/mod.rs
+++ b/src/pathed/mod.rs
@@ -1,5 +1,5 @@
-#[cfg_attr(target_os = "linux", path = "linux.rs")]
-#[cfg_attr(not(target_os = "linux"), path = "all.rs")]
+#[cfg_attr(any(target_os = "linux", target_os = "netbsd"), path = "linux.rs")]
+#[cfg_attr(not(any(target_os = "linux", target_os = "netbsd")), path = "all.rs")]
 mod os;
 
 pub(crate) use os::*;

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -207,8 +207,8 @@ pub struct OpenArchiveDataEx {
 #[link(name = "unrar", kind = "static")]
 #[cfg_attr(all(windows, target_env = "gnu"), link(name = "stdc++", kind = "static", modifiers = "-bundle"))]
 #[cfg_attr(target_os = "macos", link(name = "c++"))]
-#[cfg_attr(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"), link(name = "c++"))]
-#[cfg_attr(target_os = "linux", link(name = "stdc++"))]
+#[cfg_attr(any(target_os = "freebsd", target_os = "openbsd"), link(name = "c++"))]
+#[cfg_attr(any(target_os = "linux", target_os = "netbsd"), link(name = "stdc++"))]
 extern "C" {
     pub fn RAROpenArchive(data: *const OpenArchiveData) -> *const Handle;
 

--- a/unrar_sys/src/lib.rs
+++ b/unrar_sys/src/lib.rs
@@ -334,12 +334,12 @@ impl OpenArchiveData {
 }
 
 impl OpenArchiveDataEx {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "netbsd"))]
     pub fn new(archive: *const c_char, mode: c_uint) -> Self {
         Self::new_internal(archive, std::ptr::null(), mode)
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "netbsd")))]
     pub fn new(archive: *const wchar_t, mode: c_uint) -> Self {
         Self::new_internal(std::ptr::null(), archive, mode)
     }


### PR DESCRIPTION
Makes `cargo test` finish the build.

I see a couple test failures:
```
     Running tests/utf8.rs (target/debug/deps/utf8-14284d5dbd0a3e88)

running 7 tests
test unicode_list ... ok
test unicode_file ... FAILED
test unicode_extract_to ... FAILED
test extract_with_unicode_base ... FAILED
test unicode_entry_extract ... FAILED
test unicode_entry ... ok
test unicode_entry_process_mode ... ok

failures:

---- unicode_file stdout ----
thread 'unicode_file' panicked at tests/utf8.rs:12:84:
called `Result::unwrap()` on an `Err` value: EOpen@Open (Could not open archive)

---- unicode_extract_to stdout ----
thread 'unicode_extract_to' panicked at tests/utf8.rs:23:69:
read failed: Os { code: 2, kind: NotFound, message: "No such file or directory" }

---- extract_with_unicode_base stdout ----
thread 'extract_with_unicode_base' panicked at tests/utf8.rs:40:62:
read failed: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- unicode_entry_extract stdout ----
thread 'unicode_entry_extract' panicked at tests/utf8.rs:67:5:
assertion `left == right` failed
  left: "unicodefilename"
 right: "unicodefilename❤\u{fe0f}.txt"


failures:
    extract_with_unicode_base
    unicode_entry_extract
    unicode_extract_to
    unicode_file

test result: FAILED. 3 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```
but it's an improvement to before, where it didn't even link.