### PR TITLE
Fix handling wrong password

### DIFF
--- a/unrar_sys/vendor/unrar/arcread.cpp
+++ b/unrar_sys/vendor/unrar/arcread.cpp
@@ -1,5 +1,8 @@
 #include "rar.hpp"
 
+#define MAX_HEAD_SIZE (1<<10) // 1 Kb
+#define MAX_DATA_SIZE (1<<27) // 128 Mb
+
 size_t Archive::ReadHeader()
 {
   // Once we failed to decrypt an encrypted block, there is no reason to
@@ -183,6 +186,11 @@ size_t Archive::ReadHeader15()
     BrokenHeaderMsg();
     return 0;
   }
+  if (Decrypt && (ShortBlock.HeadSize>MAX_HEAD_SIZE))
+  {
+    FailedHeaderDecryption=true;
+    return 0;
+  }
 
   // For simpler further processing we map header types common
   // for RAR 1.5 and 5.0 formats to RAR 5.0 values. It does not include
@@ -254,7 +262,7 @@ size_t Archive::ReadHeader15()
         hd->SplitAfter=(hd->Flags & LHD_SPLIT_AFTER)!=0;
         hd->Encrypted=(hd->Flags & LHD_PASSWORD)!=0;
         hd->SaltSet=(hd->Flags & LHD_SALT)!=0;
-        
+
         // RAR versions earlier than 2.0 do not set the solid flag
         // in file header. They use only a global solid archive flag.
         hd->Solid=FileBlock && (hd->Flags & LHD_SOLID)!=0;
@@ -266,6 +274,12 @@ size_t Archive::ReadHeader15()
         hd->Version=(hd->Flags & LHD_VERSION)!=0;
 
         hd->DataSize=Raw.Get4();
+        if (Decrypt && (hd->DataSize>MAX_DATA_SIZE))
+        {
+          FailedHeaderDecryption=true;
+          return 0;
+        }
+
         uint LowUnpSize=Raw.Get4();
         hd->HostOS=Raw.Get1();
 
@@ -462,6 +476,11 @@ size_t Archive::ReadHeader15()
     case HEAD3_PROTECT:
       ProtectHead.SetBaseBlock(ShortBlock);
       ProtectHead.DataSize=Raw.Get4();
+      if (Decrypt && (ProtectHead.DataSize>MAX_DATA_SIZE))
+      {
+        FailedHeaderDecryption=true;
+        return 0;
+      }
       ProtectHead.Version=Raw.Get1();
       ProtectHead.RecSectors=Raw.Get2();
       ProtectHead.TotalBlocks=Raw.Get4();
@@ -471,6 +490,11 @@ size_t Archive::ReadHeader15()
     case HEAD3_OLDSERVICE: // RAR 2.9 and earlier.
       SubBlockHead.SetBaseBlock(ShortBlock);
       SubBlockHead.DataSize=Raw.Get4();
+      if (Decrypt && (SubBlockHead.DataSize>MAX_DATA_SIZE))
+      {
+        FailedHeaderDecryption=true;
+        return 0;
+      }
       NextBlockPos+=SubBlockHead.DataSize;
       SubBlockHead.SubType=Raw.Get2();
       SubBlockHead.Level=Raw.Get1();
@@ -514,7 +538,7 @@ size_t Archive::ReadHeader15()
   // but included them into CRC, so it couldn't be verified with generic
   // approach here.
   if (ShortBlock.HeadCRC!=HeaderCRC && ShortBlock.HeaderType!=HEAD3_SIGN &&
-      ShortBlock.HeaderType!=HEAD3_AV && 
+      ShortBlock.HeaderType!=HEAD3_AV &&
       (ShortBlock.HeaderType!=HEAD3_OLDSERVICE || SubBlockHead.SubType!=UO_HEAD))
   {
     bool Recovered=false;
@@ -541,6 +565,11 @@ size_t Archive::ReadHeader15()
         return 0;
       }
     }
+  }
+  if (Decrypt && (NextBlockPos > FileLength()))
+  {
+    FailedHeaderDecryption=true;
+    return 0;
   }
 
   return Raw.Size();
@@ -581,7 +610,7 @@ size_t Archive::ReadHeader50()
     RarCheckPassword CheckPwd;
     if (CryptHead.UsePswCheck && !BrokenHeader)
       CheckPwd.Set(CryptHead.Salt,HeadersInitV,CryptHead.Lg2Count,CryptHead.PswCheck);
-    
+
     while (true) // Repeat the password prompt for wrong passwords.
     {
       RequestArcPassword(CheckPwd.IsSet() ? &CheckPwd:NULL);


### PR DESCRIPTION
There's a problem when unpacking encrypted archives with version 1.5 of the header (magic number `52 61 72 21 1a 07 00`).

It occurs when reading headers: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L140

* Reading the data block and decrypting with a password: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L164
* Getting the header type: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L175-L180
* Because the data is decrypted without any control (https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/crypt.cpp#L40), then the header type is random if the password is incorrect.
* Next, there's a CRC check (16 bits are inherently risky), but only for certain header types: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L516-L541
* If, by chance, the header type is one of the following: `HEAD3_SIGN`, `HEAD3_AV`, `HEAD3_OLDSERVICE`, `UO_HEAD`, the file isn't marked as broken (`FailedHeaderDecryption != true`)
* We calculate the position of the next block, which extends beyond the end of the file: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L505-L506
* When reading the next header, we realize that the file has unexpectedly ended: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L154-L158
* We exit without errors, but the UI displays a warning: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/arcread.cpp#L108-L109
* If the header type didn't match, there would be errors: https://github.com/muja/unrar.rs/blob/0.5.8/unrar_sys/vendor/unrar/dll.cpp#L223-L231

After updating `unrar_sys` to the latest version of the `unrar` source code (https://www.rarlab.com/rar/unrarsrc-7.2.6.tar.gz) the problem persists.

If you run the `unrar` command, it displays a warning:

```bash
❯ unrar t -pFAKE_PWD sample.rar

Unexpected end of archive

Testing archive sample.rar

Unexpected end of archive
No files to extract
```

This PR performs additional checks; the idea is borrowed from 7zip:

* `HeadSize` > 1 KB: https://github.com/ip7z/7zip/blob/26.01/CPP/7zip/Archive/Rar/RarHandler.cpp#L741-L745
* `DataSize` > 128 MB: https://github.com/ip7z/7zip/blob/26.01/CPP/7zip/Archive/Rar/RarHandler.cpp#L758-L762
* `NewPos` > `FileSize`: https://github.com/ip7z/7zip/blob/26.01/CPP/7zip/Archive/Rar/RarHandler.cpp#L770-L774
