### PR TITLE
fix: guard callback against null/misaligned pointers on multi-volume RAR (SIGABRT)

### DIFF
--- a/src/open_archive.rs
+++ b/src/open_archive.rs
@@ -513,11 +513,23 @@ impl<M: ProcessMode> Internal<M> {
         let user_data = unsafe { &mut *(user_data as *mut Userdata<M::Output>) };
         match msg {
             native::UCM_CHANGEVOLUMEW => {
-                // 2048 seems to be the buffer size in unrar,
-                // also it's the maximum path length since 5.00.
-                let next =
-                    unsafe { widestring::WideCString::from_ptr_truncate(p1 as *const _, 2048) };
-                user_data.1 = Some(next);
+                // Guard against null OR misaligned pointers. libunrar should pass
+                // a valid, aligned wide-string pointer here, but at volume-boundary
+                // crossings it can hand us null or a non-null pointer that is not
+                // aligned to `WideChar` (u32 on Unix, u16 on Windows).
+                // `from_ptr_truncate` copies via `ptr::copy_nonoverlapping`, whose
+                // safety precondition requires the source to be non-null AND aligned;
+                // violating it is UB and aborts the process under debug pointer
+                // checks. Skip in that case — libunrar still locates the next volume
+                // by path, and the `RAR_VOL_ASK => -1` stop path below is preserved.
+                let p = p1 as *const widestring::WideChar;
+                if !p.is_null() && (p as usize) % std::mem::align_of::<widestring::WideChar>() == 0
+                {
+                    // 2048 seems to be the buffer size in unrar,
+                    // also it's the maximum path length since 5.00.
+                    let next = unsafe { widestring::WideCString::from_ptr_truncate(p, 2048) };
+                    user_data.1 = Some(next);
+                }
                 match p2 {
                     // Next volume not found. -1 means stop
                     native::RAR_VOL_ASK => -1,
@@ -526,8 +538,14 @@ impl<M: ProcessMode> Internal<M> {
                 }
             }
             native::UCM_PROCESSDATA => {
-                let raw_slice = std::ptr::slice_from_raw_parts(p1 as *const u8, p2 as _);
-                M::process_data(&mut user_data.0, unsafe { &*raw_slice as &_ });
+                // Guard against null pointer or zero-count callbacks that
+                // libunrar may send at volume-boundary crossings. Creating a
+                // Rust reference from a null pointer is always UB (even for
+                // zero-length slices), so we skip the call in that case.
+                if p1 != 0 && p2 > 0 {
+                    let raw_slice = std::ptr::slice_from_raw_parts(p1 as *const u8, p2 as usize);
+                    M::process_data(&mut user_data.0, unsafe { &*raw_slice as &_ });
+                }
                 0
             }
             _ => 0,

--- a/src/open_archive.rs
+++ b/src/open_archive.rs
@@ -517,18 +517,28 @@ impl<M: ProcessMode> Internal<M> {
                 // a valid, aligned wide-string pointer here, but at volume-boundary
                 // crossings it can hand us null or a non-null pointer that is not
                 // aligned to `WideChar` (u32 on Unix, u16 on Windows).
-                // `from_ptr_truncate` copies via `ptr::copy_nonoverlapping`, whose
-                // safety precondition requires the source to be non-null AND aligned;
-                // violating it is UB and aborts the process under debug pointer
-                // checks. Skip in that case — libunrar still locates the next volume
-                // by path, and the `RAR_VOL_ASK => -1` stop path below is preserved.
+                // Reading through such a pointer is UB and aborts under the debug
+                // pointer checks. Skip — libunrar still finds the volume by path,
+                // and the `RAR_VOL_ASK => -1` stop path below is preserved.
+                // `from_ptr_truncate` is also unusable here: it bulk-copies all
+                // 2048 elements before truncating at the nul, over-reading past
+                // the (usually much shorter) volume-name buffer. Scan instead.
                 let p = p1 as *const widestring::WideChar;
                 if !p.is_null() && (p as usize) % std::mem::align_of::<widestring::WideChar>() == 0
                 {
                     // 2048 seems to be the buffer size in unrar,
                     // also it's the maximum path length since 5.00.
-                    let next = unsafe { widestring::WideCString::from_ptr_truncate(p, 2048) };
-                    user_data.1 = Some(next);
+                    let mut chars: Vec<widestring::WideChar> = Vec::new();
+                    for i in 0..2048usize {
+                        // SAFETY: `p` is non-null and aligned; every element up to
+                        // and including the nul lies inside unrar's buffer.
+                        let ch = unsafe { p.add(i).read() };
+                        if ch == 0 {
+                            break;
+                        }
+                        chars.push(ch);
+                    }
+                    user_data.1 = Some(widestring::WideCString::from_vec_truncate(chars));
                 }
                 match p2 {
                     // Next volume not found. -1 means stop


### PR DESCRIPTION
## Problem

Processing a **multi-volume RAR** archive can abort the whole process with `SIGABRT` at a volume boundary. Two distinct failure modes, both in `Internal::callback` (`src/open_archive.rs`):

1. **`UCM_PROCESSDATA`** reliably `SIGABRT`s when a file's data crosses a volume boundary.
2. **`UCM_CHANGEVOLUMEW`** *intermittently* `SIGABRT`s at a volume change (more readily reproduced under parallel test runs).

## Root cause

libunrar-supplied pointers are used without null/alignment checks:

- `UCM_CHANGEVOLUMEW`: `widestring::WideCString::from_ptr_truncate(p1, 2048)` copies wide chars via `ptr::copy_nonoverlapping`, whose safety precondition requires the source to be **non-null and aligned** to `widestring::WideChar` (`u32` on Unix, `u16` on Windows). At a volume change libunrar can hand over a null pointer, or a non-null pointer that is not aligned to `WideChar`.
- `UCM_PROCESSDATA`: `slice_from_raw_parts(p1, p2)` + `&*raw_slice` builds a Rust reference even when `p1` is null. Creating a reference from a null pointer is UB **even for a zero-length slice**. (`p1` is `*const u8`, alignment 1, so only null/size matter here.)

The resulting UB is caught by Rust's runtime precondition checks (debug assertions / nightly) and becomes a non-unwinding panic across the C++ FFI frame → `SIGABRT`. The `UCM_CHANGEVOLUMEW` variant is timing/layout sensitive, so it surfaces intermittently.

## Fix

Guard both callbacks. The guards are conservative:

- Skipping a null/misaligned `UCM_CHANGEVOLUMEW` name only omits recording the next-volume name; libunrar still locates volumes by path, and the `RAR_VOL_ASK => -1` stop path is preserved.
- Skipping a null/empty `UCM_PROCESSDATA` chunk drops nothing real (a real chunk has `p1 != null` and `p2 > 0`).

`unrar_sys` is untouched — only the safe Rust wrapper changes.

## Reproduction

Create a multi-volume RAR (`rar a -ma4 -v2k arc.rar bigfile`) and process the first volume via the crate's API on a build with debug assertions (Rust nightly's pointer-precondition checks):

- Without the `UCM_PROCESSDATA` guard it `SIGABRT`s when the payload crosses into `arc.part2.rar`.
- Without the `UCM_CHANGEVOLUMEW` alignment guard it `SIGABRT`s intermittently at the volume change.

With both guards, listing and extraction complete correctly.

## Notes

- `widestring::WideChar` is a public alias in the `widestring` dependency (`u32` on Unix, `u16` on Windows), so `align_of::<WideChar>()` is the correct, portable alignment to check.
- `cargo build` and `rustfmt --check` are clean.